### PR TITLE
Ldap Auth support for managerDn, managerPassword, userSearchFilter

### DIFF
--- a/docker/properties-builder.sh
+++ b/docker/properties-builder.sh
@@ -72,6 +72,12 @@ auth.authenticationProviders=${AUTH_AUTHENTICATION_PROVIDERS:-STANDARD}
 # This is your active directory url
 # auth.adUrl=${AUTH_AD_URL:-}
 
+# LDAP User Search Filter can be used instead of Dn Pattern
+auth.ldapUserSearchFilter=${AUTH_LDAP_USER_SEARCH_FILTER:-}
+# If LDAP is configured with a manager Dn and password add the properties
+auth.ldapManagerDn=${AUTH_LDAP_MANAGER_DN:-}
+auth.ldapManagerPassword=${AUTH_LDAP_MANAGER_PWD:-}
+
 # Needed if you want to query ldap
 # auth.ldapBindUser=${AUTH_LDAP_BIND_USER:-}
 # auth.ldapBindPass=${AUTH_LDAP_BIND_PASS:-}

--- a/src/main/java/com/capitalone/dashboard/auth/AuthProperties.java
+++ b/src/main/java/com/capitalone/dashboard/auth/AuthProperties.java
@@ -37,6 +37,25 @@ public class AuthProperties {
 
 	private boolean ldapDisableGroupAuthorization = false;
 
+	/**
+	 * The LDAP filter used to search for users (optional). For example "(&(objectClass=user)(sAMAccountName={0}))". The
+	 * substituted parameter is the user's login name.
+	 **/
+	private String ldapUserSearchFilter;
+
+	/**
+	 * Username (DN) of the "manager" user identity (i.e. "uid=admin,ou=system") which
+	 * will be used to authenticate to a (non-embedded) LDAP server. If omitted,
+	 * anonymous access will be used.
+	 **/
+	private String ldapManagerDn;
+
+	/**
+	 * The password for the manager DN. This is required if the ldapManagerDn is
+	 * specified.
+	 **/
+	private String ldapManagerPassword;
+
 	// -- SSO properties
 	private String userEid;
 	private String userEmail;
@@ -132,6 +151,30 @@ public class AuthProperties {
 
 	public void setLdapDisableGroupAuthorization(boolean ldapDisableGroupAuthorization) {
 		this.ldapDisableGroupAuthorization = ldapDisableGroupAuthorization;
+	}
+
+	public String getLdapUserSearchFilter() {
+		return ldapUserSearchFilter;
+	}
+
+	public void setLdapUserSearchFilter(String ldapUserSearchFilter) {
+		this.ldapUserSearchFilter = ldapUserSearchFilter;
+	}
+
+	public String getLdapManagerDn() {
+		return ldapManagerDn;
+	}
+
+	public void setLdapManagerDn(String ldapManagerDn) {
+		this.ldapManagerDn = ldapManagerDn;
+	}
+
+	public String getLdapManagerPassword() {
+		return ldapManagerPassword;
+	}
+
+	public void setLdapManagerPassword(String ldapManagerPassword) {
+		this.ldapManagerPassword = ldapManagerPassword;
 	}
 
 	@PostConstruct


### PR DESCRIPTION
Support for additional ldap auth properties
- ldapUserSearchFilter : The LDAP filter used to search for users (optional). For example "(&(objectClass=user)(sAMAccountName={0}))". The substituted parameter is the user's login name. This property can be substituted for ldapUserDnPattern
- ldapManagerDn : Username (DN) of the "manager" user identity (i.e. "uid=admin,ou=system") which will be used to authenticate to a (non-embedded) LDAP server. If omitted, anonymous access will be used.
- ldapManagerPassword : The password for the manager DN. This is required if the ldapManagerDn is specified.