### PR TITLE
Updating db name to dashboarddb

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,4 +1,4 @@
-dbname=dashboard
+dbname=dashboarddb
 dbhost=localhost
 dbport=27017
 dbreplicaset=false


### PR DESCRIPTION
Updating to change the default name to align with what is suggested to use in the documentation.