### PR TITLE
Updates to AutoDiscoveryService and add unit tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,7 @@
     </parent>
 
     <properties>
-        <com.capitalone.dashboard.core.version>3.1.4</com.capitalone.dashboard.core.version>
+        <com.capitalone.dashboard.core.version>3.1.5</com.capitalone.dashboard.core.version>
         <apache.rat.plugin.version>0.13</apache.rat.plugin.version>
         <coveralls.maven.plugin.version>4.3.0</coveralls.maven.plugin.version>
         <guava.version>18.0</guava.version>

--- a/src/main/java/com/capitalone/dashboard/service/AutoDiscoveryServiceImpl.java
+++ b/src/main/java/com/capitalone/dashboard/service/AutoDiscoveryServiceImpl.java
@@ -1,6 +1,7 @@
 package com.capitalone.dashboard.service;
 
 import com.capitalone.dashboard.misc.HygieiaException;
+import com.capitalone.dashboard.model.AutoDiscoveredEntry;
 import com.capitalone.dashboard.model.AutoDiscovery;
 import com.capitalone.dashboard.repository.AutoDiscoveryRepository;
 import com.capitalone.dashboard.model.AutoDiscoveryRemoteRequest;
@@ -10,6 +11,7 @@ import org.bson.types.ObjectId;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
 
 @Service
 public class AutoDiscoveryServiceImpl implements AutoDiscoveryService {
@@ -23,18 +25,23 @@ public class AutoDiscoveryServiceImpl implements AutoDiscoveryService {
 
     @Override
     public AutoDiscovery save(AutoDiscoveryRemoteRequest request) throws HygieiaException {
-        final String METHOD_NAME = "AutoDiscoveryServiceImpl.save";
         String autoDiscoveryId = request.getAutoDiscoveryId();
-        if (! ObjectId.isValid(autoDiscoveryId) ) {
-            throw new HygieiaException("Invalid Auto Discovery Object ID: " + autoDiscoveryId + " received.", HygieiaException.BAD_DATA);
+        if (autoDiscoveryId==null || !ObjectId.isValid(autoDiscoveryId)) {
+            throw new HygieiaException("Invalid Auto Discovery Object ID: [" + autoDiscoveryId + "] received.", HygieiaException.BAD_DATA);
         }
 
-        AutoDiscovery autoDiscovery = requestToAutoiscovery( request );
         ObjectId id = new ObjectId(autoDiscoveryId);
+        AutoDiscovery autoDiscovery = null;
 
         if (autoDiscoveryRepository.exists(id)) {
-            autoDiscovery.setId(id);
+            // update existing AutoDiscovery record with the status from request
+            autoDiscovery = autoDiscoveryRepository.findOne(id);
+            updateAutoiscovery(autoDiscovery, request);
+        } else {
+            // create new AutoDiscovery record
+            autoDiscovery = requestToAutoiscovery(request);
         }
+
         autoDiscoveryRepository.save(autoDiscovery);
         return autoDiscovery;
     }
@@ -49,4 +56,38 @@ public class AutoDiscoveryServiceImpl implements AutoDiscoveryService {
                 request.getDeploymentEntries(), request.getLibraryScanEntries(), request.getFunctionalTestEntries(), request.getArtifactEntries(),
                 request.getStaticCodeEntries(), request.getFeatureEntries());
     }
+
+
+    /**
+     * Update the AutoDiscovery Entries' status from the request.
+     * @param autoDiscovery
+     * @param request
+     */
+    private void updateAutoiscovery(AutoDiscovery autoDiscovery, AutoDiscoveryRemoteRequest request) {
+        updateEntryStatus(request.getCodeRepoEntries(), autoDiscovery.getCodeRepoEntries());
+        updateEntryStatus(request.getBuildEntries(), autoDiscovery.getBuildEntries());
+        updateEntryStatus(request.getSecurityScanEntries(), autoDiscovery.getSecurityScanEntries());
+        updateEntryStatus(request.getDeploymentEntries(), autoDiscovery.getDeploymentEntries());
+        updateEntryStatus(request.getLibraryScanEntries(), autoDiscovery.getLibraryScanEntries());
+        updateEntryStatus(request.getFunctionalTestEntries(), autoDiscovery.getFunctionalTestEntries());
+        updateEntryStatus(request.getArtifactEntries(), autoDiscovery.getArtifactEntries());
+        updateEntryStatus(request.getStaticCodeEntries(), autoDiscovery.getStaticCodeEntries());
+        updateEntryStatus(request.getFeatureEntries(), autoDiscovery.getFeatureEntries());
+    }
+
+    /**
+     * Update the AutoDiscovery Entries' status from source to target.
+     * @param source
+     * @param target
+     */
+    private void updateEntryStatus(List<AutoDiscoveredEntry> source, List<AutoDiscoveredEntry> target) {
+        for (AutoDiscoveredEntry srcEntry : source) {
+            target.stream().forEach(entry -> {
+                if(entry.getOptions().equals(srcEntry.getOptions())){
+                    entry.setStatus(srcEntry.getStatus());
+                }
+            });
+        }
+    }
+
 }

--- a/src/test/java/com/capitalone/dashboard/config/TestAuthConfig.java
+++ b/src/test/java/com/capitalone/dashboard/config/TestAuthConfig.java
@@ -301,6 +301,6 @@ public class TestAuthConfig {
     public FeatureFlagService featureFlagService(){return Mockito.mock(FeatureFlagService.class);}
 
     @Bean
-    public AutoDiscoveryService autoDiscoveryServiceService(){return Mockito.mock(AutoDiscoveryService.class);}
+    public AutoDiscoveryService autoDiscoveryService() {return Mockito.mock(AutoDiscoveryService.class);}
 }
 

--- a/src/test/java/com/capitalone/dashboard/config/TestConfig.java
+++ b/src/test/java/com/capitalone/dashboard/config/TestConfig.java
@@ -283,5 +283,5 @@ public class TestConfig {
     }
 
     @Bean
-    public AutoDiscoveryService autoDiscoveryServiceService(){return Mockito.mock(AutoDiscoveryService.class);}
+    public AutoDiscoveryService autoDiscoveryService() {return Mockito.mock(AutoDiscoveryService.class);}
 }

--- a/src/test/java/com/capitalone/dashboard/config/TestDefaultAuthConfig.java
+++ b/src/test/java/com/capitalone/dashboard/config/TestDefaultAuthConfig.java
@@ -287,7 +287,7 @@ import org.springframework.context.annotation.ComponentScan;
 	 @Bean
 	 public FeatureFlagService featureFlagService(){return Mockito.mock(FeatureFlagService.class);}
 
-    @Bean
-    public AutoDiscoveryService autoDiscoveryServiceService(){return Mockito.mock(AutoDiscoveryService.class);}
+	 @Bean
+	 public AutoDiscoveryService autoDiscoveryService(){return Mockito.mock(AutoDiscoveryService.class);}
  }
 

--- a/src/test/java/com/capitalone/dashboard/service/AutoDiscoveryRemoteServiceTest.java
+++ b/src/test/java/com/capitalone/dashboard/service/AutoDiscoveryRemoteServiceTest.java
@@ -1,0 +1,209 @@
+package com.capitalone.dashboard.service;
+
+import com.capitalone.dashboard.config.ApiTestConfig;
+import com.capitalone.dashboard.config.FongoConfig;
+import com.capitalone.dashboard.misc.HygieiaException;
+import com.capitalone.dashboard.model.AutoDiscoveredEntry;
+import com.capitalone.dashboard.model.AutoDiscovery;
+import com.capitalone.dashboard.model.AutoDiscoveryMetaData;
+import com.capitalone.dashboard.model.AutoDiscoveryStatusType;
+import com.capitalone.dashboard.model.AutoDiscoveryRemoteRequest;
+import com.capitalone.dashboard.repository.AutoDiscoveryRepository;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.bson.types.ObjectId;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration(classes = {ApiTestConfig.class, FongoConfig.class})
+@DirtiesContext
+public class AutoDiscoveryRemoteServiceTest {
+
+    private static AutoDiscoveryRemoteRequest ad0, ad1, ad2;
+    private static AutoDiscoveryMetaData adMeta0, adMeta1, adMeta2;
+    private static List<AutoDiscoveredEntry> codeRepoEntries = null;
+    private static List<AutoDiscoveredEntry> buildEntries = null;
+    private static List<AutoDiscoveredEntry> securityScanEntries = null;
+    private static List<AutoDiscoveredEntry> deploymentEntries = null;
+    private static List<AutoDiscoveredEntry> libraryScanEntries = null;
+    private static List<AutoDiscoveredEntry> functionalTestEntries = null;
+    private static List<AutoDiscoveredEntry> artifactEntries = null;
+    private static List<AutoDiscoveredEntry> staticCodeEntries = null;
+    private static List<AutoDiscoveredEntry> featureEntries = null;
+
+    @Autowired
+    private AutoDiscoveryService autoSvc;
+
+    @Autowired
+    private AutoDiscoveryRepository autoRepo;
+
+    @Before
+    public void setUp() {
+
+        codeRepoEntries = new ArrayList<>();
+        buildEntries = new ArrayList<>();
+        securityScanEntries = new ArrayList<>();
+        deploymentEntries = new ArrayList<>();
+        libraryScanEntries = new ArrayList<>();
+        functionalTestEntries = new ArrayList<>();
+        artifactEntries = new ArrayList<>();
+        staticCodeEntries = new ArrayList<>();
+        featureEntries = new ArrayList<>();
+
+        adMeta0 = new AutoDiscoveryMetaData();
+        adMeta0.setApplicationName("DummyApp");
+        adMeta0.setBusinessApplication("BizApp11222333");
+        adMeta0.setBusinessService("BizApp334440");
+        adMeta0.setTemplate("template");
+        adMeta0.setTitle("testAUTO_DISCOVERY");
+        adMeta0.setType("Product");
+
+        ad0 = new AutoDiscoveryRemoteRequest(adMeta0, codeRepoEntries, buildEntries, securityScanEntries, deploymentEntries,
+                libraryScanEntries, functionalTestEntries, artifactEntries, staticCodeEntries, featureEntries, "17458071acd72450923475bb");
+
+        AutoDiscoveredEntry codeRepoEntry = new AutoDiscoveredEntry();
+        codeRepoEntry.setDescription("Hygieia GitHub");
+        codeRepoEntry.setToolName("GitHub");
+        codeRepoEntry.setStatus(AutoDiscoveryStatusType.USER_REJECTED);
+        codeRepoEntry.getOptions().put("branch", "master");
+        codeRepoEntry.getOptions().put("url", "https://github.com/Hygieia");
+        codeRepoEntries.add(codeRepoEntry);
+
+        adMeta1 = new AutoDiscoveryMetaData();
+        adMeta1.setApplicationName("HygieiaApp");
+        adMeta1.setBusinessApplication("BizApp12345678");
+        adMeta1.setBusinessService("BizApp123456");
+        adMeta1.setTemplate("template");
+        adMeta1.setTitle("testAUTO_DISCOVERY");
+        adMeta1.setType("Team");
+
+        ad1 = new AutoDiscoveryRemoteRequest(adMeta1, codeRepoEntries, buildEntries, securityScanEntries, deploymentEntries,
+                libraryScanEntries, functionalTestEntries, artifactEntries, staticCodeEntries, featureEntries, "5d67f7b5066a8b0fe6cbfb61");
+
+        AutoDiscoveredEntry artifactEntry = new AutoDiscoveredEntry();
+        artifactEntry.setDescription("Hygieia Artifactory");
+        artifactEntry.setToolName("Artifactory");
+        artifactEntry.setStatus(AutoDiscoveryStatusType.USER_REJECTED);
+        artifactEntry.getOptions().put("path", "some/path");
+        artifactEntry.getOptions().put("artifactName", "HygieiaArtifactory");
+        artifactEntry.getOptions().put("instanceUrl", "http://www.artifact.com");
+        artifactEntries.add(artifactEntry);
+
+        adMeta2 = new AutoDiscoveryMetaData();
+        adMeta2.setApplicationName("ApplicationNameStr");
+        adMeta2.setBusinessApplication("BusinessApplicationStr");
+        adMeta2.setBusinessService("BusinessServiceStr");
+        adMeta2.setTemplate("template");
+        adMeta2.setTitle("testTitle");
+        adMeta2.setType("Team");
+
+        ad2 = new AutoDiscoveryRemoteRequest(adMeta2, codeRepoEntries, buildEntries, securityScanEntries, deploymentEntries,
+                libraryScanEntries, functionalTestEntries, artifactEntries, staticCodeEntries, featureEntries, "5d67f7b5066a8b0fe6cbfb99");
+    }
+
+    @After
+    public void tearDown() {
+        codeRepoEntries = null;
+        buildEntries = null;
+        securityScanEntries = null;
+        deploymentEntries = null;
+        libraryScanEntries = null;
+        functionalTestEntries = null;
+        artifactEntries = null;
+        staticCodeEntries = null;
+        featureEntries = null;
+        autoRepo.deleteAll();
+    }
+
+    @Test
+    public void testCreateNewAutoDiscovery() throws HygieiaException {
+        autoSvc.save(ad0);
+        autoSvc.save(ad1);
+        autoSvc.save(ad2);
+        assertTrue("Failed to create new AutoDiscovery records", autoRepo.findAll().iterator().hasNext());
+        assertEquals(autoRepo.count(), 3);
+    }
+
+    @Test
+    public void testUpdateAutoDiscovery() throws HygieiaException {
+        autoSvc.save(ad0);
+        assertEquals(autoRepo.count(), 1);
+
+        AutoDiscovery ad = autoRepo.findAll().iterator().next();
+        ad0.setAutoDiscoveryId(ad.getId().toHexString());
+        ad0.getMetaData().setTitle("new title");  // this should not persist
+        ad0.getMetaData().setTemplate("new template");  // this should not persist
+        autoSvc.save(ad0);
+
+        assertEquals(autoRepo.count(), 1);
+        ad = autoRepo.findAll().iterator().next();
+        // we should not update anything else other than the status for the AutoDiscoveredEntry
+        assertEquals(ad.getMetaData().getTitle(), "testAUTO_DISCOVERY");
+        assertEquals(ad.getMetaData().getTemplate(), "template");
+    }
+
+    @Test
+    public void testUpdateStatusOnly() throws HygieiaException {
+        autoSvc.save(ad2);
+        assertEquals(autoRepo.count(), 1);
+
+        AutoDiscovery ad = autoRepo.findAll().iterator().next();
+        ObjectId id2 = ad.getId();
+
+        autoSvc.save(ad1);
+        assertEquals(autoRepo.count(), 2);
+        ad = autoRepo.findOne(id2);
+        assertNotNull(ad);
+        assertNotNull(ad.getCodeRepoEntries());
+        assertEquals(ad.getCodeRepoEntries().size(),1);
+        assertFalse(ad.getArtifactEntries().isEmpty());
+
+        // now try to update ad2
+        ad2.setAutoDiscoveryId(id2.toHexString());
+        ad2.setCodeRepoEntries(new ArrayList<>());
+        AutoDiscoveredEntry artifactEntry = ad2.getArtifactEntries().iterator().next();
+        artifactEntry.setStatus(AutoDiscoveryStatusType.AWAITING_USER_RESPONSE); // this should persist
+        artifactEntry.setDescription("new artifactory descriptions blah blah"); // this should not persist
+        autoSvc.save(ad2);
+        assertEquals(autoRepo.count(), 2);
+        ad = autoRepo.findOne(id2);
+        assertFalse(ad.getCodeRepoEntries().isEmpty());
+        assertFalse(ad.getArtifactEntries().isEmpty());
+
+        artifactEntry = ad.getArtifactEntries().iterator().next();
+        assertEquals(artifactEntry.getStatus(), AutoDiscoveryStatusType.AWAITING_USER_RESPONSE);
+        // we should not update anything else other than the status for the AutoDiscoveredEntry, so description should not change
+        assertEquals(artifactEntry.getDescription(), "Hygieia Artifactory");
+
+        AutoDiscoveredEntry codeRepoEntry = ad.getCodeRepoEntries().iterator().next();
+        assertEquals(codeRepoEntry.getStatus(), AutoDiscoveryStatusType.USER_REJECTED);
+        assertEquals(codeRepoEntry.getDescription(), "Hygieia GitHub");
+    }
+
+    @Test
+    public void testException_badObjId() {
+        ad0.setAutoDiscoveryId("this is a bad object id");
+        try {
+            autoSvc.save(ad0);
+            fail("Expected an HygieiaException to be thrown");
+        } catch (HygieiaException hex) {
+            assertEquals(hex.getMessage(), "Invalid Auto Discovery Object ID: [this is a bad object id] received.");
+        }
+    }
+
+}


### PR DESCRIPTION
When updating an existing AutoDiscovery record, only update the status, not any other fields.

Created unit tests for create/update happy paths, and exception handling when updating existing records.

update core version to 3.1.5