### PR TITLE
set AutoDsicovery ModifiedTimestamp to current system time

### DIFF
--- a/src/main/java/com/capitalone/dashboard/service/AutoDiscoveryServiceImpl.java
+++ b/src/main/java/com/capitalone/dashboard/service/AutoDiscoveryServiceImpl.java
@@ -37,9 +37,13 @@ public class AutoDiscoveryServiceImpl implements AutoDiscoveryService {
             // update existing AutoDiscovery record with the status from request
             autoDiscovery = autoDiscoveryRepository.findOne(id);
             updateAutoiscovery(autoDiscovery, request);
+            autoDiscovery.setModifiedTimestamp(System.currentTimeMillis());
         } else {
             // create new AutoDiscovery record
             autoDiscovery = requestToAutoiscovery(request);
+            long currTime = System.currentTimeMillis();
+            autoDiscovery.setCreatedTimestamp(currTime);
+            autoDiscovery.setModifiedTimestamp(currTime);
         }
 
         autoDiscoveryRepository.save(autoDiscovery);

--- a/src/test/java/com/capitalone/dashboard/service/AutoDiscoveryRemoteServiceTest.java
+++ b/src/test/java/com/capitalone/dashboard/service/AutoDiscoveryRemoteServiceTest.java
@@ -184,7 +184,7 @@ public class AutoDiscoveryRemoteServiceTest {
         ad = autoRepo.findOne(id2);
         assertFalse(ad.getCodeRepoEntries().isEmpty());
         assertFalse(ad.getArtifactEntries().isEmpty());
-        assertTrue(ad.getModifiedTimestamp()-System.currentTimeMillis() < 1 );
+        assertNotNull(ad.getModifiedTimestamp());
 
         artifactEntry = ad.getArtifactEntries().iterator().next();
         assertEquals(artifactEntry.getStatus(), AutoDiscoveryStatusType.AWAITING_USER_RESPONSE);

--- a/src/test/java/com/capitalone/dashboard/service/AutoDiscoveryRemoteServiceTest.java
+++ b/src/test/java/com/capitalone/dashboard/service/AutoDiscoveryRemoteServiceTest.java
@@ -184,6 +184,7 @@ public class AutoDiscoveryRemoteServiceTest {
         ad = autoRepo.findOne(id2);
         assertFalse(ad.getCodeRepoEntries().isEmpty());
         assertFalse(ad.getArtifactEntries().isEmpty());
+        assertTrue(ad.getModifiedTimestamp()-System.currentTimeMillis() < 1 );
 
         artifactEntry = ad.getArtifactEntries().iterator().next();
         assertEquals(artifactEntry.getStatus(), AutoDiscoveryStatusType.AWAITING_USER_RESPONSE);


### PR DESCRIPTION
When updating AutoDsicovery records, set the ModifiedTimestamp to current system time