### PR TITLE
Fixes issue with Jwt Signature error not returning Unauthorized

### DIFF
--- a/src/main/java/com/capitalone/dashboard/auth/token/TokenAuthenticationServiceImpl.java
+++ b/src/main/java/com/capitalone/dashboard/auth/token/TokenAuthenticationServiceImpl.java
@@ -11,6 +11,7 @@ import java.util.Date;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import io.jsonwebtoken.SignatureException;
 import org.apache.commons.lang.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.core.Authentication;
@@ -64,7 +65,7 @@ public class TokenAuthenticationServiceImpl implements TokenAuthenticationServic
 			
 			return authentication;
 			
-		} catch (ExpiredJwtException e) {
+		} catch (ExpiredJwtException | SignatureException e) {
 			return null;
 		}
 	}


### PR DESCRIPTION
Jwt Signature error was not being caught resulting in a 500 response. Updating the catch block to catch it to return unauthorized.