### PR TITLE
Malformated jwt is handled

### DIFF
--- a/src/main/java/com/capitalone/dashboard/auth/token/TokenAuthenticationServiceImpl.java
+++ b/src/main/java/com/capitalone/dashboard/auth/token/TokenAuthenticationServiceImpl.java
@@ -3,6 +3,7 @@ package com.capitalone.dashboard.auth.token;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.MalformedJwtException;
 import io.jsonwebtoken.SignatureAlgorithm;
 
 import java.util.Collection;
@@ -65,7 +66,7 @@ public class TokenAuthenticationServiceImpl implements TokenAuthenticationServic
 			
 			return authentication;
 			
-		} catch (ExpiredJwtException | SignatureException e) {
+		} catch (ExpiredJwtException | SignatureException | MalformedJwtException e) {
 			return null;
 		}
 	}

--- a/src/test/java/com/capitalone/dashboard/auth/token/TokenAuthenticationServiceImplTest.java
+++ b/src/test/java/com/capitalone/dashboard/auth/token/TokenAuthenticationServiceImplTest.java
@@ -63,6 +63,12 @@ public class TokenAuthenticationServiceImplTest {
 		when(request.getHeader(AUTHORIZATION)).thenReturn(null);
 		assertNull(service.getAuthentication(request));
 	}
+
+	@Test
+	public void testGetAuthentication_MalformedJWT() {
+		when(request.getHeader(AUTHORIZATION)).thenReturn("null");
+		assertNull(service.getAuthentication(request));
+	}
 	
 	@Test
 	public void testGetAuthentication_expiredToken() {


### PR DESCRIPTION
#50 JWT Error

Hello, the problem with authentication was that the front end is sending an authorization header with "null" value, so the server can't parse this token JWT and an exception is throwed.

Front-end sets a undefined value
![image](https://user-images.githubusercontent.com/13066717/74281411-680e9380-4cec-11ea-9d23-a8bb506596e9.png)

Server gets a "null" value
![image](https://user-images.githubusercontent.com/13066717/74281425-6e9d0b00-4cec-11ea-9bd2-30b828b7713b.png)

This PR fix that problem,
Have a nice day