### PR TITLE
cmdb remoteCreate accepting business service ID as alternative; dashboard remoteCreate behaves as remoteUpdate when existing

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <artifactId>api</artifactId>
     <packaging>jar</packaging>
     <name>${project.groupId}:${project.artifactId}</name>
-    <version>3.2.6-SNAPSHOT</version>
+    <version>3.2.7-SNAPSHOT</version>
     <description>Hygieia Rest API Layer</description>
     <url>https://github.com/Hygieia/api</url>
 

--- a/src/main/java/com/capitalone/dashboard/request/CmdbRequest.java
+++ b/src/main/java/com/capitalone/dashboard/request/CmdbRequest.java
@@ -16,6 +16,9 @@ public class CmdbRequest {
     private String assignmentGroup;
     @NotNull
     private String ownerDept;
+
+    private String businessService;
+
     /**
      * commonName Human readable value of the configurationItem
      */
@@ -92,4 +95,11 @@ public class CmdbRequest {
     public void setToolName(String toolName) {
         this.toolName = toolName;
     }
+
+    public String getBusinessService() {
+        return businessService;
+    }
+
+    public void setBusinessService(String businessService) { this.businessService = businessService; }
+
 }

--- a/src/main/java/com/capitalone/dashboard/rest/CmdbController.java
+++ b/src/main/java/com/capitalone/dashboard/rest/CmdbController.java
@@ -6,6 +6,8 @@ import com.capitalone.dashboard.request.CmdbRequest;
 import com.capitalone.dashboard.service.CmdbRemoteService;
 import com.capitalone.dashboard.service.CmdbService;
 import com.capitalone.dashboard.util.PaginationHeaderUtility;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -30,6 +32,8 @@ public class CmdbController {
     private final CmdbService cmdbService;
     private final CmdbRemoteService cmdbRemoteService;
     private PaginationHeaderUtility paginationHeaderUtility;
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(CmdbController.class);
 
     @Autowired
     public CmdbController(CmdbService cmdbService, PaginationHeaderUtility paginationHeaderUtility, CmdbRemoteService cmdbRemoteService ) {
@@ -62,6 +66,7 @@ public class CmdbController {
                     .status( HttpStatus.CREATED )
                     .body( cmdbRemoteService.remoteCreate( request ) );
         } catch (HygieiaException he) {
+            LOGGER.error("Failed to create cmdb entry", he);
             return ResponseEntity
                     .status( HttpStatus.BAD_REQUEST )
                     .body( he.getMessage() );

--- a/src/main/java/com/capitalone/dashboard/rest/DashboardRemoteController.java
+++ b/src/main/java/com/capitalone/dashboard/rest/DashboardRemoteController.java
@@ -5,6 +5,9 @@ import com.capitalone.dashboard.misc.HygieiaException;
 import com.capitalone.dashboard.model.Dashboard;
 import com.capitalone.dashboard.request.DashboardRemoteRequest;
 import com.capitalone.dashboard.service.DashboardRemoteService;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -20,9 +23,9 @@ import static org.springframework.web.bind.annotation.RequestMethod.POST;
 @RestController
 public class DashboardRemoteController {
 
-//    private static final Logger LOGGER = LoggerFactory.getLogger(DashboardRemoteController.class);
-    private final DashboardRemoteService dashboardRemoteService;
+    private static final Logger LOGGER = LoggerFactory.getLogger(DashboardRemoteController.class);
 
+    private final DashboardRemoteService dashboardRemoteService;
 
     @Autowired
     public DashboardRemoteController(DashboardRemoteService dashboardRemoteService) {
@@ -37,7 +40,8 @@ public class DashboardRemoteController {
             return ResponseEntity
                     .status(HttpStatus.CREATED)
                     .body("Successfully created dashboard: id =" + dashboard.getId());
-        } catch (HygieiaException he) {
+        } catch (Exception he) {
+            LOGGER.error("RemoteCreate receives exception", he);
             return ResponseEntity
                     .status(HttpStatus.BAD_REQUEST)
                     .body("Failed to create dashboard. Error: " + he.getMessage());
@@ -52,7 +56,8 @@ public class DashboardRemoteController {
             return ResponseEntity
                     .status(HttpStatus.CREATED)
                     .body("Successfully updated dashboard: id =" + dashboard.getId());
-        } catch (HygieiaException he) {
+        } catch (Exception he) {
+            LOGGER.error("RemoteUpdate receives exception", he);
             return ResponseEntity
                     .status(HttpStatus.BAD_REQUEST)
                     .body("Failed to update dashboard. Error: " + he.getMessage());

--- a/src/main/java/com/capitalone/dashboard/service/DashboardServiceImpl.java
+++ b/src/main/java/com/capitalone/dashboard/service/DashboardServiceImpl.java
@@ -181,10 +181,10 @@ public class DashboardServiceImpl implements DashboardService {
         Iterable<Component> components = null;
 
         if(!isUpdate) {
+            dashboard.setCreatedAt(System.currentTimeMillis());
             components = componentRepository.save(dashboard.getApplication().getComponents());
-        } else {
-            dashboard.setUpdatedAt(System.currentTimeMillis());
         }
+        dashboard.setUpdatedAt(System.currentTimeMillis());
 
         try {
             duplicateDashboardErrorCheck(dashboard);

--- a/src/test/java/com/capitalone/dashboard/service/CmdbRemoteServiceTest.java
+++ b/src/test/java/com/capitalone/dashboard/service/CmdbRemoteServiceTest.java
@@ -49,7 +49,7 @@ public class CmdbRemoteServiceTest {
         ObjectId objectId = ObjectId.get();
         expected.setId(objectId);
         CmdbRequest request = makeCmdbRequest("BAPTEST", "subtype",
-                "type", "assignmentgroup","owner", "BAPTEST", "", "cmdbCollector");
+                "type", "assignmentgroup","owner", "BAPTEST", null, "", "cmdbCollector");
         when(cmdbRepository.findByConfigurationItemAndItemType("","" )).thenReturn(null);
         when(collectorService.createCollectorItem(Matchers.any(CollectorItem.class) )).thenReturn(makeCollectorItem());
         when(collectorRepository.findByCollectorTypeAndName(CollectorType.CMDB, request.getToolName())).thenReturn(makeCollector( request.getToolName(), CollectorType.CMDB));
@@ -69,7 +69,7 @@ public class CmdbRemoteServiceTest {
         ObjectId objectId = ObjectId.get();
         expected.setId(objectId);
         CmdbRequest request = makeCmdbRequest("BAPTEST", "subtype",
-                "type", "assignmentgroup","owner", "BAPTEST", "ASVTEST", "cmdbCollector");
+                "type", "assignmentgroup","owner", "BAPTEST", null,"ASVTEST", "cmdbCollector");
         when(cmdbRepository.findByConfigurationItemAndItemType("","" )).thenReturn(null);
         when(collectorService.createCollectorItem(Matchers.any(CollectorItem.class) )).thenReturn(makeCollectorItem());
         when(collectorRepository.findByCollectorTypeAndName(CollectorType.CMDB, request.getToolName())).thenReturn(makeCollector( request.getToolName(), CollectorType.CMDB));
@@ -84,6 +84,29 @@ public class CmdbRemoteServiceTest {
             assertEquals(excep.getMessage(), e.getMessage());
         }
     }
+
+    /**
+     * Test the use of businessService instead of configurationItemBusServName in the request.
+     * @throws HygieiaException
+     */
+    @Test
+    public void remoteCreateUsingBusinessService() throws HygieiaException {
+        Cmdb businessServiceItem = makeCmdbItem("CI123456", "subtype",
+                "type", "assignmentgroup","owner", "ASVTEST");
+        Cmdb expected = makeCmdbItem("BAPTEST", "subtype",
+                "type", "assignmentgroup","owner", "BAPTEST");
+        ObjectId objectId = ObjectId.get();
+        expected.setId(objectId);
+        CmdbRequest request = makeCmdbRequest("BAPTEST", "subtype",
+                "type", "assignmentgroup","owner", "BAPTEST", "CI123456", "", "cmdbCollector");
+        when(cmdbRepository.findByConfigurationItemAndItemType("CI123456","app" )).thenReturn(businessServiceItem);
+        when(collectorService.createCollectorItem(Matchers.any(CollectorItem.class) )).thenReturn(makeCollectorItem());
+        when(collectorRepository.findByCollectorTypeAndName(CollectorType.CMDB, request.getToolName())).thenReturn(makeCollector( request.getToolName(), CollectorType.CMDB));
+        when(cmdbRepository.save(Matchers.any(Cmdb.class))).thenReturn(expected);
+
+        assertThat(cmdbRemoteService.remoteCreate(request), is(expected));
+    }
+
     /**
      * Tests remoteCreate functionality ConfigurationItemBusServName doesn't have existing relationships
      * @throws HygieiaException
@@ -97,7 +120,7 @@ public class CmdbRemoteServiceTest {
         ObjectId objectId = ObjectId.get();
         expected.setId(objectId);
         CmdbRequest request = makeCmdbRequest("BAPTEST", "subtype",
-                "type", "assignmentgroup","owner", "BAPTEST", "ASVTEST", "cmdbCollector");
+                "type", "assignmentgroup","owner", "BAPTEST", null,"ASVTEST", "cmdbCollector");
         when(cmdbRepository.findByConfigurationItemAndItemType("","" )).thenReturn(null);
         when(collectorService.createCollectorItem(Matchers.any(CollectorItem.class) )).thenReturn(makeCollectorItem());
         when(collectorRepository.findByCollectorTypeAndName(CollectorType.CMDB, request.getToolName())).thenReturn(makeCollector( request.getToolName(), CollectorType.CMDB));
@@ -122,7 +145,7 @@ public class CmdbRemoteServiceTest {
         ObjectId objectId = ObjectId.get();
         expected.setId(objectId);
         CmdbRequest request = makeCmdbRequest("BAPTEST", "subtype",
-                "type", "assignmentgroup","owner", "BAPTEST", "ASVTEST", "cmdbCollector");
+                "type", "assignmentgroup","owner", "BAPTEST",  null,"ASVTEST", "cmdbCollector");
         when(cmdbRepository.findByConfigurationItemAndItemType("","" )).thenReturn(null);
         when(collectorService.createCollectorItem(Matchers.any(CollectorItem.class) )).thenReturn(makeCollectorItem());
         when(collectorRepository.findByCollectorTypeAndName(CollectorType.CMDB, request.getToolName())).thenReturn(makeCollector( request.getToolName(), CollectorType.CMDB));
@@ -154,6 +177,7 @@ public class CmdbRemoteServiceTest {
                                         String assignmentGroup,
                                         String ownerDept,
                                         String commonName,
+                                        String businessService,
                                         String configurationItemBusServName,
                                         String toolName){
 
@@ -164,6 +188,7 @@ public class CmdbRemoteServiceTest {
         request.setAssignmentGroup(assignmentGroup);
         request.setOwnerDept(ownerDept);
         request.setCommonName(commonName);
+        request.setBusinessService(businessService);
         request.setConfigurationItemBusServName(configurationItemBusServName);
         request.setToolName(toolName);
         return request;

--- a/src/test/java/com/capitalone/dashboard/service/DashboardRemoteServiceTest.java
+++ b/src/test/java/com/capitalone/dashboard/service/DashboardRemoteServiceTest.java
@@ -39,7 +39,11 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration(classes = {ApiTestConfig.class, FongoConfig.class})

--- a/src/test/java/com/capitalone/dashboard/service/DashboardRemoteServiceTest.java
+++ b/src/test/java/com/capitalone/dashboard/service/DashboardRemoteServiceTest.java
@@ -39,10 +39,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.fail;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.*;
 
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration(classes = {ApiTestConfig.class, FongoConfig.class})
@@ -210,18 +207,15 @@ public class DashboardRemoteServiceTest {
         }
     }
     @Test
-    public void remoteCreateDuplicateDashboard() throws IOException {
+    public void remoteCreateDuplicateDashboard() throws HygieiaException, IOException {
         DashboardRemoteRequest request = getRemoteRequest("./dashboardRemoteRequests/0-Remote-Update-Repo.json");
         Dashboard dashboard = dashboardRepository.findByTitle(request.getMetaData().getTitle()).get(0);
         Throwable t = new Throwable();
         RuntimeException excep = new RuntimeException("Dashboard "+dashboard.getTitle()+" (id =" + dashboard.getId() + ") already exists", t);
 
-        try {
-            dashboardRemoteService.remoteCreate(request, false);
-            fail("Should throw RuntimeException");
-        } catch(Exception e) {
-            assertEquals(excep.getMessage(), e.getMessage());
-        }
+        Dashboard found = dashboardRemoteService.remoteCreate(request, false);
+        assertEquals(dashboard.getId(), found.getId());
+        assertTrue(found.getUpdatedAt()>dashboard.getUpdatedAt());
     }
     @Test
     public void remoteCreate() throws HygieiaException, IOException  {


### PR DESCRIPTION
cmdb remoteCreate accepting business service ID as alternative
dashboard remoteCreate behaves as remoteUpdate when the dashboard already exists (instead of returning 400 HTTP code)