### PR TITLE
log client correlation id from response header

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <artifactId>api</artifactId>
     <packaging>jar</packaging>
     <name>${project.groupId}:${project.artifactId}</name>
-    <version>3.4.16-SNAPSHOT</version>
+    <version>3.4.17-SNAPSHOT</version>
     <description>Hygieia Rest API Layer</description>
     <url>https://github.com/Hygieia/api</url>
 

--- a/src/main/java/com/capitalone/dashboard/auth/token/JwtAuthenticationFilter.java
+++ b/src/main/java/com/capitalone/dashboard/auth/token/JwtAuthenticationFilter.java
@@ -44,7 +44,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         String correlation_id = request.getHeader(CommonConstants.HEADER_CLIENT_CORRELATION_ID);
         apiUser = (StringUtils.isEmpty(apiUser)? "API_USER" : apiUser);
         correlation_id = (StringUtils.isEmpty(correlation_id)) ? "NULL" : correlation_id;
-        if(response != null)
+        if(response != null && !StringUtils.equals("NULL", correlation_id))
             response.addHeader(CommonConstants.HEADER_CLIENT_CORRELATION_ID, correlation_id);
         /*
          * apiToken based authentication
@@ -53,6 +53,12 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             try {
                 filterChain.doFilter(request, response);
             } finally {
+                String response_correlation_id = null;
+                if(response != null ){
+                    response_correlation_id = response.getHeader(CommonConstants.HEADER_CLIENT_CORRELATION_ID);
+                    correlation_id = StringUtils.isNotEmpty(response_correlation_id) ? response_correlation_id : correlation_id;
+                    response.addHeader(CommonConstants.HEADER_CLIENT_CORRELATION_ID, correlation_id);
+                }
                 // no logging on ping request
                 if(!StringUtils.containsIgnoreCase(request.getRequestURI(), PING)) {
                     String parameters = MapUtils.isEmpty(request.getParameterMap()) ? "NONE" :

--- a/src/main/java/com/capitalone/dashboard/rest/BuildController.java
+++ b/src/main/java/com/capitalone/dashboard/rest/BuildController.java
@@ -90,7 +90,8 @@ public class BuildController {
         String response_message = "Successfully created/updated build : "+ response.getId();
         LOGGER.info("correlation_id="+response.getClientReference() +", application=hygieia, service=api, uri=" + httpServletRequest.getRequestURI()
                 + ", requester=" + requester + ", response_status=success, response_code=" + HttpStatus.CREATED.value()
-                + ", response_status_message=" + response_message + ", build_url=" + request.getBuildUrl());
+                + ", response_status_message=" + response_message + ", build_url=" + request.getBuildUrl()
+                + ", build_status=" + BuildStatus.fromString(request.getBuildStatus()));
         return ResponseEntity
                 .status(HttpStatus.CREATED)
                 .header(CommonConstants.HEADER_CLIENT_CORRELATION_ID,response.getClientReference())


### PR DESCRIPTION
- Add build_status to buildController logging
- In JwtAuthFilter, some transactions set the client_reference in the response header and need to account for it.