### PR TITLE
Update GitHub workflow to use JDK 11

### DIFF
--- a/.github/workflows/maven-snapshot-release.yml
+++ b/.github/workflows/maven-snapshot-release.yml
@@ -7,13 +7,13 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
 
     steps:
     - uses: actions/checkout@v1
-    - name: Set up JDK 1.8
+    - name: Set up JDK 11
       uses: actions/setup-java@v1
       with:
-        java-version: 1.8
+        java-version: 11
     - name: Release to snapshots repository
       run: mvn deploy -q --file pom.xml --settings src/devops/.travis.settings.xml -Denv.OSSRH_USERNAME=${{ secrets.OSSRH_USERNAME }} -Denv.OSSRH_PASSWORD=${{ secrets.OSSRH_PASSWORD }}


### PR DESCRIPTION
<!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
   this work for additional information regarding copyright ownership.
   The ASF licenses this file to You under the Apache License, Version 2.0
   (the "License"); you may not use this file except in compliance with
   the License.  You may obtain a copy of the License at
       http://www.apache.org/licenses/LICENSE-2.0
   Unless required by applicable law or agreed to in writing, software
   distributed under the License is distributed on an "AS IS" BASIS,
   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
   See the License for the specific language governing permissions and
   limitations under the License.
-->
<!--
!!! For Security Vulnerabilities, please go to https://gitter.im/capitalone/Hygieia and find
    an active team memberl, request their email address, and email directly!!!
-->
Use JDK 11 for Maven Snapshot Release Workflow.

The workflow currently produces the following error.
`Error:  Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:3.1:compile (default-compile) on project api: Fatal error compiling: invalid target release: 11 -> [Help 1]`

Upgrade deprecated GitHub Actions runner to ubuntu-latest.
"Deprecation will begin on 2022/08/08 and the image will be fully unsupported by 2023/04/01"
`The ubuntu-18.04 environment is deprecated, consider switching to ubuntu-20.04(ubuntu-latest), or ubuntu-22.04 instead. For more details see` https://github.com/actions/runner-images/issues/6002

---
<!--
- For bugs, specify affected versions and explain what you are trying to do.
- For enhancements, provide context and describe the problem.

Issue or Pull Request? Create only one, not both. GitHub treats them as the same.
If unsure, start with an issue, and if you submit a pull request later, the
issue will be closed as superseded.
-->
